### PR TITLE
fix knrc post/metadata

### DIFF
--- a/blog/2023-02-10-cyclonedx-maven-plugin-adventure-continues.md
+++ b/blog/2023-02-10-cyclonedx-maven-plugin-adventure-continues.md
@@ -1,6 +1,6 @@
 ---
 title: "Continuing the Adventure with the CycloneDX Maven Plugin"
-authors: ctron
+authors: kevinconner
 tags: [cyclonedx]
 ---
 

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -11,8 +11,8 @@ danbev:
 kevinconner:
   name: Kevin Conner
   title: Maintainer
-  url: https://github.com/kevinconner
-  image_url: https://github.com/kevinconner.png
+  url: https://github.com/knrc
+  image_url: https://github.com/knrc.png
 ctron:
   name: Jens Reimann
   title: Maintainer


### PR DESCRIPTION
I was searching for my blog posts from last year, and noticed that the information is not correct (metadata points to my old GH account and one post has Jens as author instead of me).

This PR should fix those issues.