### PR TITLE
Revert gh action upgrades

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -5,9 +5,9 @@ jobs:
   build-pr-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - name: Build
@@ -20,11 +20,11 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: build
           path: build/
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -13,7 +13,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download build
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -33,7 +33,7 @@ jobs:
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/build.zip', Buffer.from(download.data));
       - name: Download PR number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         with:
           script: |
             var artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -57,7 +57,7 @@ jobs:
       - run: unzip pr.zip
 
       - name: Generate issue_number
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         id: issue_number
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,7 +67,7 @@ jobs:
           result-encoding: string
 
       - name: Generate Surge URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v3
         id: surge-url
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,8 +10,8 @@ jobs:
     name: "Github pages"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Build
@@ -19,7 +19,7 @@ jobs:
           npm ci
           npm run build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build


### PR DESCRIPTION
The Preview Deploy gh workflow stopped working. Reverting changes to set the actions to a "working" state.
Once we make all our workflows work again we can open further PRs to upgrade whatever dependency we need but first making sure we are not breaking working actions